### PR TITLE
동시성 관련 통합테스트

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -34,8 +34,8 @@ dependencies {
 
     implementation("org.jetbrains.kotlin:kotlin-reflect")
 
-    runtimeOnly("com.h2database:h2")
     runtimeOnly("org.mariadb.jdbc:mariadb-java-client")
+//    testRuntimeOnly("com.h2database:h2")
 
 //    developmentOnly("org.springframework.boot:spring-boot-devtools")
 

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -18,7 +18,7 @@ spring:
     activate:
       on-profile: local
   datasource:
-      driver-class-name: org.h2.Driver
+      driver-class-name: org.mariadb.jdbc.Driver
       url: jdbc:h2:mem:coupon_db
       username: sa
       password:

--- a/src/test/kotlin/org/yellowsunn/couponconcurrency/config/TestDataSourceConfig.kt
+++ b/src/test/kotlin/org/yellowsunn/couponconcurrency/config/TestDataSourceConfig.kt
@@ -1,0 +1,24 @@
+package org.yellowsunn.couponconcurrency.config
+
+import com.zaxxer.hikari.HikariDataSource
+import org.springframework.boot.context.properties.ConfigurationProperties
+import org.springframework.boot.jdbc.DataSourceBuilder
+import org.springframework.boot.test.context.TestConfiguration
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Primary
+
+@TestConfiguration
+class TestDataSourceConfig {
+    @Primary
+    @Bean(name = ["mainDataSource"])
+    @ConfigurationProperties(prefix = "spring.main.datasource.hikari")
+    fun mainDataSource(): HikariDataSource {
+        return DataSourceBuilder.create().type(HikariDataSource::class.java).build()
+    }
+
+    @Bean(name = ["lockDataSource"])
+    @ConfigurationProperties(prefix = "spring.lock.datasource.hikari")
+    fun lockDataSource(): HikariDataSource {
+        return DataSourceBuilder.create().type(HikariDataSource::class.java).build()
+    }
+}

--- a/src/test/kotlin/org/yellowsunn/couponconcurrency/service/CouponLockTestTemplate.kt
+++ b/src/test/kotlin/org/yellowsunn/couponconcurrency/service/CouponLockTestTemplate.kt
@@ -7,9 +7,9 @@ import java.util.concurrent.atomic.AtomicInteger
 
 fun <T> executeWithLockTemplate(
     numberOfThread: Int = 10,
-    businessLogic: Supplier<T>,
     logicSuccessCount: AtomicInteger = AtomicInteger(0),
     logicFailCount: AtomicInteger = AtomicInteger(0),
+    businessLogic: Supplier<T>,
 ) {
     val countDownLatch = CountDownLatch(numberOfThread)
     val executorService = Executors.newFixedThreadPool(numberOfThread)

--- a/src/test/kotlin/org/yellowsunn/couponconcurrency/service/CouponLockTestTemplate.kt
+++ b/src/test/kotlin/org/yellowsunn/couponconcurrency/service/CouponLockTestTemplate.kt
@@ -1,0 +1,32 @@
+package org.yellowsunn.couponconcurrency.service
+
+import org.apache.logging.log4j.util.Supplier
+import java.util.concurrent.CountDownLatch
+import java.util.concurrent.Executors
+import java.util.concurrent.atomic.AtomicInteger
+
+fun <T> executeWithLockTemplate(
+    numberOfThread: Int = 10,
+    businessLogic: Supplier<T>,
+    logicSuccessCount: AtomicInteger = AtomicInteger(0),
+    logicFailCount: AtomicInteger = AtomicInteger(0),
+) {
+    val countDownLatch = CountDownLatch(numberOfThread)
+    val executorService = Executors.newFixedThreadPool(numberOfThread)
+
+    for (thread in 1..numberOfThread) {
+        executorService.execute {
+            try {
+                businessLogic.get()
+                logicSuccessCount.getAndIncrement()
+            } catch (e: RuntimeException) {
+                logicFailCount.getAndIncrement()
+            } finally {
+                countDownLatch.countDown()
+            }
+        }
+    }
+
+    countDownLatch.await()
+    executorService.shutdown()
+}

--- a/src/test/kotlin/org/yellowsunn/couponconcurrency/service/CouponRollbackStrategies.kt
+++ b/src/test/kotlin/org/yellowsunn/couponconcurrency/service/CouponRollbackStrategies.kt
@@ -1,0 +1,48 @@
+package org.yellowsunn.couponconcurrency.service
+
+import org.springframework.data.redis.core.RedisTemplate
+import org.springframework.stereotype.Component
+import org.yellowsunn.couponconcurrency.repository.persistence.jpa.UserCouponJpaRepository
+
+@Component
+class CouponRollbackStrategies(
+    private val userCouponJpaRepository: UserCouponJpaRepository,
+    private val redisTemplate: RedisTemplate<String, String>,
+) {
+    companion object {
+        private const val COUPON_TOTAL_COUNT_PREFIX = "coupon"
+        private const val LOCK_KEY_PREFIX = "test"
+    }
+
+    fun clean(
+        couponId: Long,
+        userId: String,
+    ) {
+        userCouponJpaRepository.deleteAll()
+
+        evictRedisLock(couponId, userId)
+        evictRedisCouponTotalCount(couponId)
+    }
+
+    private fun evictRedisLock(
+        couponId: Long,
+        userId: String,
+    ) {
+        redisTemplate.delete(getRedisLockNames(couponId, userId))
+    }
+
+    private fun evictRedisCouponTotalCount(couponId: Long) {
+        redisTemplate.delete(getRedisTotalCountName(couponId))
+    }
+
+    private fun getRedisLockNames(
+        couponId: Long,
+        userId: String,
+    ): List<String> {
+        return listOf(LOCK_KEY_PREFIX, "${LOCK_KEY_PREFIX}:$userId:$couponId")
+    }
+
+    private fun getRedisTotalCountName(couponId: Long): String {
+        return "$COUPON_TOTAL_COUNT_PREFIX:$couponId"
+    }
+}

--- a/src/test/kotlin/org/yellowsunn/couponconcurrency/service/CouponWithLockTest.kt
+++ b/src/test/kotlin/org/yellowsunn/couponconcurrency/service/CouponWithLockTest.kt
@@ -1,0 +1,116 @@
+package org.yellowsunn.couponconcurrency.service
+
+import org.assertj.core.api.Assertions
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertAll
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.context.SpringBootTest
+import org.yellowsunn.couponconcurrency.service.v1.CouponFacadeV1
+import org.yellowsunn.couponconcurrency.service.v2.CouponFacadeV2
+import org.yellowsunn.couponconcurrency.service.v3.CouponFacadeV3
+import org.yellowsunn.couponconcurrency.service.v4.CouponFacadeV4
+import java.util.concurrent.atomic.AtomicInteger
+
+@SpringBootTest
+class CouponWithLockTest {
+    companion object {
+        private const val COUPON_ID = 1L
+        private const val USER_ID = "test user"
+    }
+
+    @Autowired lateinit var couponFacadeV1: CouponFacadeV1
+
+    @Autowired lateinit var couponFacadeV2: CouponFacadeV2
+
+    @Autowired lateinit var couponFacadeV3: CouponFacadeV3
+
+    @Autowired lateinit var couponFacadeV4: CouponFacadeV4
+
+    @Autowired lateinit var rollbackStrategies: CouponRollbackStrategies
+
+    @AfterEach
+    fun rollBack() {
+        rollbackStrategies.clean(COUPON_ID, USER_ID)
+    }
+
+    @Test
+    fun v1_namedLockTest() {
+        // given
+        val numberOfThread = 10
+
+        val successCount = AtomicInteger(0)
+        val failCount = AtomicInteger(0)
+
+        // when
+        executeWithLockTemplate(numberOfThread = numberOfThread, {
+            couponFacadeV1.giveCoupon(COUPON_ID, USER_ID)
+        }, logicSuccessCount = successCount, logicFailCount = failCount)
+
+        // then
+        assertAll(
+            { Assertions.assertThat(successCount.get()).isEqualTo(1) },
+            { Assertions.assertThat(failCount.get()).isEqualTo(numberOfThread - 1) },
+        )
+    }
+
+    @Test
+    fun v2_specificNamedLockTest() {
+        // given
+        val numberOfThread = 10
+
+        val successCount = AtomicInteger(0)
+        val failCount = AtomicInteger(0)
+
+        // when
+        executeWithLockTemplate(numberOfThread = numberOfThread, {
+            couponFacadeV2.giveCoupon(COUPON_ID, USER_ID)
+        }, logicSuccessCount = successCount, logicFailCount = failCount)
+
+        // then
+        assertAll(
+            { Assertions.assertThat(successCount.get()).isEqualTo(1) },
+            { Assertions.assertThat(failCount.get()).isEqualTo(numberOfThread - 1) },
+        )
+    }
+
+    @Test
+    fun v3_spinLockTest() {
+        // given
+        val numberOfThread = 10
+
+        val successCount = AtomicInteger(0)
+        val failCount = AtomicInteger(0)
+
+        // when
+        executeWithLockTemplate(numberOfThread = numberOfThread, {
+            couponFacadeV3.giveCoupon(COUPON_ID, USER_ID)
+        }, logicSuccessCount = successCount, logicFailCount = failCount)
+
+        // then
+        assertAll(
+            { Assertions.assertThat(successCount.get()).isEqualTo(1) },
+            { Assertions.assertThat(failCount.get()).isEqualTo(numberOfThread - 1) },
+        )
+    }
+
+    @Test
+    fun v4_distributedLockUsingRedissonTest() {
+        // given
+        val numberOfThread = 10
+
+        val successCount = AtomicInteger(0)
+        val failCount = AtomicInteger(0)
+
+        // when
+        executeWithLockTemplate(numberOfThread = numberOfThread, {
+            couponFacadeV4.giveCoupon(COUPON_ID, USER_ID)
+        }, logicSuccessCount = successCount, logicFailCount = failCount)
+
+        // then
+        assertAll(
+            { Assertions.assertThat(successCount.get()).isEqualTo(1) },
+            { Assertions.assertThat(failCount.get()).isEqualTo(numberOfThread - 1) },
+        )
+    }
+}

--- a/src/test/kotlin/org/yellowsunn/couponconcurrency/service/CouponWithLockTest.kt
+++ b/src/test/kotlin/org/yellowsunn/couponconcurrency/service/CouponWithLockTest.kt
@@ -19,15 +19,20 @@ class CouponWithLockTest {
         private const val USER_ID = "test user"
     }
 
-    @Autowired lateinit var couponFacadeV1: CouponFacadeV1
+    @Autowired
+    lateinit var couponFacadeV1: CouponFacadeV1
 
-    @Autowired lateinit var couponFacadeV2: CouponFacadeV2
+    @Autowired
+    lateinit var couponFacadeV2: CouponFacadeV2
 
-    @Autowired lateinit var couponFacadeV3: CouponFacadeV3
+    @Autowired
+    lateinit var couponFacadeV3: CouponFacadeV3
 
-    @Autowired lateinit var couponFacadeV4: CouponFacadeV4
+    @Autowired
+    lateinit var couponFacadeV4: CouponFacadeV4
 
-    @Autowired lateinit var rollbackStrategies: CouponRollbackStrategies
+    @Autowired
+    lateinit var rollbackStrategies: CouponRollbackStrategies
 
     @AfterEach
     fun rollBack() {
@@ -43,9 +48,9 @@ class CouponWithLockTest {
         val failCount = AtomicInteger(0)
 
         // when
-        executeWithLockTemplate(numberOfThread = numberOfThread, {
+        executeWithLockTemplate(numberOfThread = numberOfThread, logicSuccessCount = successCount, logicFailCount = failCount) {
             couponFacadeV1.giveCoupon(COUPON_ID, USER_ID)
-        }, logicSuccessCount = successCount, logicFailCount = failCount)
+        }
 
         // then
         assertAll(
@@ -63,9 +68,9 @@ class CouponWithLockTest {
         val failCount = AtomicInteger(0)
 
         // when
-        executeWithLockTemplate(numberOfThread = numberOfThread, {
+        executeWithLockTemplate(numberOfThread = numberOfThread, logicSuccessCount = successCount, logicFailCount = failCount) {
             couponFacadeV2.giveCoupon(COUPON_ID, USER_ID)
-        }, logicSuccessCount = successCount, logicFailCount = failCount)
+        }
 
         // then
         assertAll(
@@ -83,9 +88,9 @@ class CouponWithLockTest {
         val failCount = AtomicInteger(0)
 
         // when
-        executeWithLockTemplate(numberOfThread = numberOfThread, {
+        executeWithLockTemplate(numberOfThread = numberOfThread, logicSuccessCount = successCount, logicFailCount = failCount) {
             couponFacadeV3.giveCoupon(COUPON_ID, USER_ID)
-        }, logicSuccessCount = successCount, logicFailCount = failCount)
+        }
 
         // then
         assertAll(
@@ -103,9 +108,9 @@ class CouponWithLockTest {
         val failCount = AtomicInteger(0)
 
         // when
-        executeWithLockTemplate(numberOfThread = numberOfThread, {
+        executeWithLockTemplate(numberOfThread = numberOfThread, logicSuccessCount = successCount, logicFailCount = failCount) {
             couponFacadeV4.giveCoupon(COUPON_ID, USER_ID)
-        }, logicSuccessCount = successCount, logicFailCount = failCount)
+        }
 
         // then
         assertAll(

--- a/src/test/resources/application.yml
+++ b/src/test/resources/application.yml
@@ -1,0 +1,26 @@
+spring:
+  main:
+    datasource:
+      hikari:
+        driver-class-name: org.mariadb.jdbc.Driver
+        jdbc-url: jdbc:mariadb://localhost:43306/test_coupon_db
+        username: root
+        password: 1234
+        connection-timeout: 1000
+        maximum-pool-size: 10
+    allow-bean-definition-overriding: true
+  lock:
+    datasource:
+      hikari:
+        driver-class-name: org.mariadb.jdbc.Driver
+        jdbc-url: jdbc:mariadb://localhost:43306/test_coupon_db
+        username: root
+        password: 1234
+        connection-timeout: 1000
+        maximum-pool-size: 100
+  data:
+    redis:
+      host: localhost
+      port: 6379
+      username:
+      password:


### PR DESCRIPTION
## 작업내용
- 테스트용 database(`test_coupon_db`) 데이터베이스 생성
- `ExecutorService`, `CountDownLatch`로 통합테스트 작성
  - 여러 요청 동시에 들어와도 정상 작동할 수 있는지 확인

`@Transactional` 안쓴 이유
- redis 관련 로직은 롤백안되고, datasource는 롤백되기에 그냥 `@AfterEach`에서 한꺼번에 컨트롤하는게 낫다 생각함
- 그래서 그냥 직접 롤백 처리함