### PR TITLE
로컬락 구현 (ReentrantLock)

### DIFF
--- a/src/main/kotlin/org/yellowsunn/couponconcurrency/controller/rest/CouponController.kt
+++ b/src/main/kotlin/org/yellowsunn/couponconcurrency/controller/rest/CouponController.kt
@@ -5,6 +5,7 @@ import org.springframework.web.bind.annotation.DeleteMapping
 import org.springframework.web.bind.annotation.PathVariable
 import org.springframework.web.bind.annotation.PostMapping
 import org.springframework.web.bind.annotation.RestController
+import org.yellowsunn.couponconcurrency.service.v0.CouponFacadeV0
 import org.yellowsunn.couponconcurrency.service.v1.CouponFacadeV1
 import org.yellowsunn.couponconcurrency.service.v2.CouponFacadeV2
 import org.yellowsunn.couponconcurrency.service.v3.CouponFacadeV3
@@ -12,13 +13,22 @@ import org.yellowsunn.couponconcurrency.service.v4.CouponFacadeV4
 
 @RestController
 class CouponController(
+    private val couponFacadeV0: CouponFacadeV0,
     private val couponFacadeV1: CouponFacadeV1,
     private val couponFacadeV2: CouponFacadeV2,
     private val couponFacadeV3: CouponFacadeV3,
     private val couponFacadeV4: CouponFacadeV4,
 ) {
+    @PostMapping("/api/v0/coupons/{couponId}")
+    fun giveCouponV0(
+        @CookieValue(value = "userId", required = true) userId: String,
+        @PathVariable couponId: Long,
+    ) {
+        return couponFacadeV0.giveCoupon(couponId = couponId, userId = userId)
+    }
+
     @PostMapping("/api/v1/coupons/{couponId}")
-    fun giveCoupon(
+    fun giveCouponV1(
         @CookieValue(value = "userId", required = true) userId: String,
         @PathVariable couponId: Long,
     ) {

--- a/src/main/kotlin/org/yellowsunn/couponconcurrency/repository/lock/local/LocalLockRepository.kt
+++ b/src/main/kotlin/org/yellowsunn/couponconcurrency/repository/lock/local/LocalLockRepository.kt
@@ -4,6 +4,7 @@ import org.apache.logging.log4j.util.Supplier
 import org.springframework.stereotype.Repository
 import org.yellowsunn.couponconcurrency.repository.lock.LockRepository
 import java.time.Duration
+import java.util.concurrent.ConcurrentHashMap
 import java.util.concurrent.TimeUnit
 import java.util.concurrent.locks.ReentrantLock
 
@@ -13,13 +14,15 @@ class LocalLockRepository : LockRepository {
         private const val FAIL_TO_ACQUIRE_LOCK_EXCEPTION_MESSAGE = "LOCK을 획득하지 못했습니다."
     }
 
-    private val lock = ReentrantLock()
+    private val locks = ConcurrentHashMap<String, ReentrantLock>()
 
     override fun <T> executeWithLock(
         lockName: String,
         timeout: Duration,
         supplier: Supplier<T>,
     ): T {
+        val lock = locks.putIfAbsent(lockName, ReentrantLock())!!
+
         try {
             val acquired = lock.tryLock(timeout.toSeconds(), TimeUnit.SECONDS)
 

--- a/src/main/kotlin/org/yellowsunn/couponconcurrency/repository/lock/local/LocalLockRepository.kt
+++ b/src/main/kotlin/org/yellowsunn/couponconcurrency/repository/lock/local/LocalLockRepository.kt
@@ -1,0 +1,40 @@
+package org.yellowsunn.couponconcurrency.repository.lock.local
+
+import org.apache.logging.log4j.util.Supplier
+import org.springframework.stereotype.Repository
+import org.yellowsunn.couponconcurrency.repository.lock.LockRepository
+import java.time.Duration
+import java.util.concurrent.TimeUnit
+import java.util.concurrent.locks.ReentrantLock
+
+@Repository
+class LocalLockRepository : LockRepository {
+    companion object {
+        private const val FAIL_TO_ACQUIRE_LOCK_EXCEPTION_MESSAGE = "LOCK을 획득하지 못했습니다."
+    }
+
+    private val lock = ReentrantLock()
+
+    override fun <T> executeWithLock(
+        lockName: String,
+        timeout: Duration,
+        supplier: Supplier<T>,
+    ): T {
+        try {
+            val acquired = lock.tryLock(timeout.toSeconds(), TimeUnit.SECONDS)
+
+            if (!acquired) {
+                throw RuntimeException(FAIL_TO_ACQUIRE_LOCK_EXCEPTION_MESSAGE)
+            }
+
+            return supplier.get()
+        } catch (e: InterruptedException) {
+            throw RuntimeException(e.message, e)
+        } finally {
+            // lock 획득 못하고 unlock 호출 시에 exception 발생하므로, 방어 로직 작성
+            if (lock.isHeldByCurrentThread) {
+                lock.unlock()
+            }
+        }
+    }
+}

--- a/src/main/kotlin/org/yellowsunn/couponconcurrency/service/v0/CouponFacadeV0.kt
+++ b/src/main/kotlin/org/yellowsunn/couponconcurrency/service/v0/CouponFacadeV0.kt
@@ -1,0 +1,23 @@
+package org.yellowsunn.couponconcurrency.service.v0
+
+import org.springframework.stereotype.Component
+import org.yellowsunn.couponconcurrency.repository.lock.LockRepository
+import java.time.Duration
+
+/**
+ * Local Lock (ReentrantLock)
+ */
+@Component
+class CouponFacadeV0(
+    private val couponServiceV0: CouponServiceV0,
+    private val localLockRepository: LockRepository,
+) {
+    fun giveCoupon(
+        couponId: Long,
+        userId: String,
+    ) {
+        localLockRepository.executeWithLock("test:$couponId:$userId", Duration.ofSeconds(1)) {
+            couponServiceV0.giveCoupon(couponId, userId)
+        }
+    }
+}

--- a/src/main/kotlin/org/yellowsunn/couponconcurrency/service/v0/CouponServiceV0.kt
+++ b/src/main/kotlin/org/yellowsunn/couponconcurrency/service/v0/CouponServiceV0.kt
@@ -1,0 +1,31 @@
+package org.yellowsunn.couponconcurrency.service.v0
+
+import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
+import org.yellowsunn.couponconcurrency.domain.UserCoupon
+import org.yellowsunn.couponconcurrency.exception.BadRequestException
+import org.yellowsunn.couponconcurrency.repository.persistence.CouponRepository
+
+@Service
+class CouponServiceV0(
+    private val couponRepository: CouponRepository,
+) {
+    @Transactional
+    fun giveCoupon(
+        couponId: Long,
+        userId: String,
+    ) {
+        val isAlreadyExist = couponRepository.existsByCouponIdAndUserId(couponId = couponId, userId = userId)
+        if (isAlreadyExist) {
+            throw BadRequestException("이미 쿠폰이 지급된 유저입니다.")
+        }
+
+        val remainCouponCount: Long = couponRepository.countRemainCoupons(couponId)
+        if (remainCouponCount <= 0L) {
+            throw BadRequestException("쿠폰이 전부 소진되어 지급이 불가능합니다.")
+        }
+
+        val newUserCoupon = UserCoupon(couponId = couponId, userId = userId)
+        couponRepository.saveUserCoupon(newUserCoupon)
+    }
+}

--- a/src/main/resources/templates/index.html
+++ b/src/main/resources/templates/index.html
@@ -33,6 +33,7 @@
   <div style="width: 1000px; height: 400px; margin: 0 auto; display: flex; flex-direction: column; justify-content: center">
     <div style="margin: 10px">남은 쿠폰 수: <span th:text="${remainCouponCount}"></span></div>
     <button type="button" class="btn btn-outline-secondary" style="margin-bottom: 10px" th:onclick="giveCoupon('v1', [[${couponId}]])">쿠폰 발급 하기</button>
+    <button type="button" class="btn btn-outline-danger" style="margin-bottom: 10px" th:onclick="giveCoupon10('v0', [[${couponId}]])">쿠폰 '따닥 (10회)' 발급 하기 (v0 - local lock(by all))</button>
     <button type="button" class="btn btn-outline-danger" style="margin-bottom: 10px" th:onclick="giveCoupon10('v1', [[${couponId}]])">쿠폰 '따닥 (10회)' 발급 하기 (v1 - db named lock(by all))</button>
     <button type="button" class="btn btn-outline-warning" style="margin-bottom: 10px" th:onclick="giveCoupon10('v2', [[${couponId}]])">쿠폰 '따닥 (10회)' 발급 하기 (v2 - db named lock(by user-coupon mapping) & redis atomic operation)</button>
     <button type="button" class="btn btn-outline-warning" style="margin-bottom: 10px" th:onclick="giveCoupon10('v3', [[${couponId}]])">쿠폰 '따닥 (10회)' 발급 하기 (v3 - redis spin lock)</button>


### PR DESCRIPTION
## 작업내용
- 로컬 락 구현
- 로컬 락 통합테스트코드

---

**`ReentrantLock` vs  `synchronized`**
- 둘 다 로컬환경에서 여러 스레드가 접근할 수 없게끔 임계영역을 설정해주는 기능을 가짐
- `synchronized`는 여러 스레드가 접근하면 하나의 스레드만 실행되고 다른 스레드는 무한정 대기하게 됨
  - 즉, 컴퓨팅 자원이 많이 낭비됨
  - 그리고 `synchronized`는 객체 자체에 잠금을 걸게 돼서, 락의 효율이 좋지 못함 (첫번째 ref 블로그 참고)
- `ReentrantLock`도 여러 스레드가 접근하면 하나의 스레드만 실행됨. 하지만 락과 관련된 기능들을 제공함으로써 컴퓨팅 자원을 효율적으로 사용 가능함
  - `ReentrantLock`은 `synchronized`와는 달리, 객체가 아니라 특정 범위에 락을 걸게 되므로 락의 성능이 조금 더 효율적임 
  - `tryLock(long timeout, TimeUnit unit)` 메서드는 파라미터로 주어진 시간동안 기다리다가 실패하게 할 수 있음
  - current thread가 락을 얻었는지 못얻었는지 등의 정보를 알 수 있다
- 그래서 MySQL JDBC Driver 코드와 Spring 에서도 synchronized에서 `ReentrantLock`으로 변경하고 있다고 함
  - [https://bugs.mysql.com/bug.php?id=110512](https://bugs.mysql.com/bug.php?id=110512)

Ref
- [https://tourspace.tistory.com/54](https://tourspace.tistory.com/54)
- [https://velog.io/@may_yun/JAVA-synchronized-VS-Reentrant-Lock-%EC%B0%A8%EC%9D%B4%EC%A0%90](https://velog.io/@may_yun/JAVA-synchronized-VS-Reentrant-Lock-%EC%B0%A8%EC%9D%B4%EC%A0%90)